### PR TITLE
Include LinkedIn in the Footer

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -62,6 +62,9 @@
             <a href="https://twitter.com/ekumenlabs" target="_blank">
               <i class="fa fa-twitter-square"></i>
             </a>
+            <a href="https://www.linkedin.com/company/ekumen" target="_blank">
+              <i class="fa fa-linkedin-square"></i>
+            </a>
           </div>
 
       </div>


### PR DESCRIPTION
This PR addresses #49 . The LinkedIn icon is included in the Website's footer.

ptal @basicNew 

Cropped image:
![ekuwebsite-footer](https://user-images.githubusercontent.com/14120807/31247905-6b161c14-a9e8-11e7-86e5-5ee46285d37a.png)