### PR TITLE
Ignore the Blog

### DIFF
--- a/DEV-NOTES.md
+++ b/DEV-NOTES.md
@@ -37,3 +37,19 @@ You should always check the HTML container and upload images to match their size
 
 - Team pictures are 200x299 pixels.
 - Client images should have a height of 40px.
+
+---
+
+## Middleman Information
+
+When running `middleman`, you can navigate to `localhost:port/__middleman/` and see the [Sitemap](https://middlemanapp.com/advanced/sitemap/), [Configuration](https://middlemanapp.com/advanced/configuration/) and [Guides](https://middlemanapp.com/).
+
+---
+
+## Ignore Files
+
+You can ignore to build something by adding to the `config.rb` file the following:
+```
+ignore "path/to/file"
+```
+Currently, we are ignoring the Blog section and its entries.

--- a/config.rb
+++ b/config.rb
@@ -14,6 +14,7 @@ require "builder"
 page "/sitemap.xml", :layout => false
 
 # Don't build the Blog section and its entries.
+# We are keeping the files for future reference.
 ignore "blog.html.erb"
 ignore "blog/*"
 

--- a/config.rb
+++ b/config.rb
@@ -13,6 +13,10 @@ set :relative_links,        true
 require "builder"
 page "/sitemap.xml", :layout => false
 
+# Don't build the Blog section and its entries.
+ignore "blog.html.erb"
+ignore "blog/*"
+
 # Allow HTML in the Markdown
 # see https://github.com/middleman/middleman/issues/1221#issuecomment-38104894
 # Note that Markdown formatting syntax is not processed within block-level HTML

--- a/source/blog.html.erb
+++ b/source/blog.html.erb
@@ -4,6 +4,9 @@ layout: page
 pageable: true
 ---
 
+<!-- NOTE: Currently the Blog section is ignored and not being built. Check the config.rb file. -->
+<!-- We are keeping these files for future reference. -->
+
 <h1>Blog</h1>
 
 <%


### PR DESCRIPTION
This PR addresses #94 . In the build process, the blog and its entries are ignored. Navigating to `/blog` gives you a 404.

In the built `sitemap.xml` file there are no references to blog.

ptal @basicNew 