### PR TITLE
Fix Bio's textboxes

### DIFF
--- a/source/stylesheets/team.scss
+++ b/source/stylesheets/team.scss
@@ -12,6 +12,12 @@
     .person-bio {
       font-size: 14px;
       word-break: break-word;
+      display: block;
+      /* For screen larger than 768px */
+      @media (min-width: $screen-sm-min) {
+        display: flex;
+        flex-direction: column;
+      }
     }
 
     .person-picture {


### PR DESCRIPTION
This PR addresses #103 .

When the text's height is longer than the picture, the text spills below it. This is desirable if the view's width is small, but undesirable at larger screens. Since you raised the issue, can you ptal, @gecofernando ?

![localhost_4567_team_ 1](https://user-images.githubusercontent.com/14120807/32382792-ed63929c-c094-11e7-81ec-8b54111ec983.png)
The text area was left as it was for widths lower than 768px and after that, it prevents the text from spilling below.

![localhost_4567_team_ 4](https://user-images.githubusercontent.com/14120807/32382856-1d769862-c095-11e7-9371-6163b4db5568.png)
At a lower width:

![localhost_4567_team_ 2](https://user-images.githubusercontent.com/14120807/32382773-e53c6f8a-c094-11e7-8c44-69d622ad1fa7.png)