### PR TITLE
Remove Horizontal Scrollbar

### DIFF
--- a/source/index.erb
+++ b/source/index.erb
@@ -284,8 +284,8 @@ priority: 1
     <h1>We’d like to help you solve hard technical problems and realize your business vision</h1>
 </div>
 </div>
-  <div class="row">
-    <div class="container">
+  <div class="container">
+    <div class="row">
       <div class="col-sm-6">
         <div align="center">
           <h3>Super-charge your team</h3>


### PR DESCRIPTION
This PR addresses #108 , the extra width that caused the Horizontal Scrollbar to show was caused by two misplaced `divs`. The `row` class has a `margin-right` of -15px. Since it was placed outside the `container` div, it caused that extra width to show.

ptal @basicNew !